### PR TITLE
Fix email link for vulnerability reporting

### DIFF
--- a/index.md
+++ b/index.md
@@ -174,7 +174,7 @@ The below testing environment: a 8-nodes AWS cluster with 1TB data; Spark-3.1.1 
 
 # 6 Security
 
-Gluten aims to provide secure software. If you discover a vulnerability, please report it promptly to [the project's PPMC](private@gluten.apache.org) or [the ASF security team](https://www.apache.org/security/). We appreciate your effort to help keep the project secure.
+Gluten aims to provide secure software. If you discover a vulnerability, please report it promptly to [the project's PPMC](mailto:private@gluten.apache.org) or [the ASF security team](https://www.apache.org/security/). We appreciate your effort to help keep the project secure.
 
 # Thanks to our contributors
 


### PR DESCRIPTION
Updated email link format for reporting vulnerabilities.

A follow-up to https://github.com/apache/incubator-gluten-site/pull/53#issuecomment-3402717128.