### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,9 +31,22 @@ github:
     merge: false
     rebase: false
 
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 staging:
-   profile: ~
-   whoami: asf-staging
+  profile:
+  whoami: asf-staging
 
 jekyll:
   whoami: main
@@ -45,8 +58,8 @@ publish:
 
 
 notifications:
-  commits:      commits@gluten.apache.org
-  issues:       commits@gluten.apache.org
+  commits: commits@gluten.apache.org
+  issues: commits@gluten.apache.org
   pullrequests: commits@gluten.apache.org
-  jobs:         commits@gluten.apache.org
-  discussions:  dev@gluten.apache.org
+  jobs: commits@gluten.apache.org
+  discussions: dev@gluten.apache.org


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
